### PR TITLE
Fix for using SConsolidator with MinGW

### DIFF
--- a/ch.hsr.ifs.sconsolidator.core/scons_files/BuildInfoCollector.py
+++ b/ch.hsr.ifs.sconsolidator.core/scons_files/BuildInfoCollector.py
@@ -113,7 +113,8 @@ def get_compiler(environ):
     if environ['PLATFORM'] == 'win32' and environ['CXX'] == 'g++':
         # because gcc and g++ are symlinks in cygwin that are only usable from the cygwin
         # console, we need to take the 'real' executables here
-        return which('g++-4') or which('g++-3')
+        # but in case it is MinGW we must return compiler from environment
+        return (which('g++-4') or which('g++-3')) or environ['CXX']
     else:
         return environ['CXX'] 
 


### PR DESCRIPTION
MinGW doesn't have g++-4 or g++-4 only g++, this path return environment compiler if can't find cygwin compiler
