### PR TITLE
Added pattern matching for GNU Fortran errors

### DIFF
--- a/ch.hsr.ifs.sconsolidator.core.tests/src/ch/hsr/ifs/sconsolidator/core/PlatformSpecificsTest.java
+++ b/ch.hsr.ifs.sconsolidator.core.tests/src/ch/hsr/ifs/sconsolidator/core/PlatformSpecificsTest.java
@@ -49,4 +49,39 @@ public class PlatformSpecificsTest {
     assertEquals("50", m.group(2));
   }
   
+  @Test
+  public void gnuFortranErrorPatternMatchWithLinuxPath() {
+	  Matcher m = PlatformSpecifics.FORT_RE.matcher("src/shapes/Circle.for:6.28:");
+	  assertTrue(m.find());
+	  assertEquals("src/shapes/Circle.for", m.group(1));
+	  assertEquals("6", m.group(2));
+  }
+
+  @Test
+  public void gnuFortranErrorPatternMatchWithLinuxPathAndWhitespace() {
+    Matcher m = PlatformSpecifics.FORT_RE.matcher("src/shapes/test with whitespace.f90:3.1:");
+    assertTrue(m.find());
+    assertEquals("src/shapes/test with whitespace.f90", m.group(1));
+    assertEquals("3", m.group(2));
+  }
+
+  @Test
+  public void gnuFortranErrorPatternMatchWithWindowsPath() {
+    Matcher m = PlatformSpecifics.FORT_RE.matcher("platform\\windows\\bcSupport.f77:48.5:");
+    assertTrue(m.find());
+    assertEquals("platform\\windows\\bcSupport.f77", m.group(1));
+    assertEquals("48", m.group(2));
+  }
+  
+  public void gnuFortranErrorPatternMatchWithOtherExts() {
+	    Matcher m = PlatformSpecifics.FORT_RE.matcher("platform\\windows\\bcSupport.f:48.5:");
+	    assertTrue(m.find());
+	    assertEquals("platform\\windows\\bcSupport.f", m.group(1));
+	    assertEquals("48", m.group(2));
+	    m = PlatformSpecifics.FORT_RE.matcher("platform\\windows\\bcSupport.f95:48.5:");
+	    assertTrue(m.find());
+	    assertEquals("platform\\windows\\bcSupport.f95", m.group(1));
+	    assertEquals("48", m.group(2));
+  }
+  
 }

--- a/ch.hsr.ifs.sconsolidator.core/src/ch/hsr/ifs/sconsolidator/core/PlatformSpecifics.java
+++ b/ch.hsr.ifs.sconsolidator.core/src/ch/hsr/ifs/sconsolidator/core/PlatformSpecifics.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 public final class PlatformSpecifics {
   public static final String NEW_LINE = System.getProperty("line.separator");
   public static final Pattern CPP_RE = Pattern.compile("(.+?(?:\\.(?:cpp|c|cc|C|cxx|h|hxx|hpp|ipp)))[:(]?([\\d]+)[)]?");
-  public static final Pattern FORT_RE = Pattern.compile("(?i)(.+?(?:\\.(?:f90|f|f77|for))):([\\d]+).([\\d]+):");
+  public static final Pattern FORT_RE = Pattern.compile("(?i)(.+?(?:\\.(?:f95|f90|f|f77|for))):([\\d]+)(?:.([\\d]+))?:");
   private static final Pattern OBJ_FILE_RE = Pattern.compile("([^\\s]+)(\\.(o|os|obj))$");
   private static final String SCONS_EXECUTABLE_NAME = isWindows() ? "scons.bat" : "scons";
 

--- a/ch.hsr.ifs.sconsolidator.core/src/ch/hsr/ifs/sconsolidator/core/PlatformSpecifics.java
+++ b/ch.hsr.ifs.sconsolidator.core/src/ch/hsr/ifs/sconsolidator/core/PlatformSpecifics.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 public final class PlatformSpecifics {
   public static final String NEW_LINE = System.getProperty("line.separator");
   public static final Pattern CPP_RE = Pattern.compile("(.+?(?:\\.(?:cpp|c|cc|C|cxx|h|hxx|hpp|ipp)))[:(]?([\\d]+)[)]?");
-  public static final Pattern FORT_RE = Pattern.compile("(?i)(.+(?:\\.(?:f90|f|f77|for))):([\\d]+).([\\d]+):");
+  public static final Pattern FORT_RE = Pattern.compile("(?i)(.+?(?:\\.(?:f90|f|f77|for))):([\\d]+).([\\d]+):");
   private static final Pattern OBJ_FILE_RE = Pattern.compile("([^\\s]+)(\\.(o|os|obj))$");
   private static final String SCONS_EXECUTABLE_NAME = isWindows() ? "scons.bat" : "scons";
 

--- a/ch.hsr.ifs.sconsolidator.core/src/ch/hsr/ifs/sconsolidator/core/PlatformSpecifics.java
+++ b/ch.hsr.ifs.sconsolidator.core/src/ch/hsr/ifs/sconsolidator/core/PlatformSpecifics.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 public final class PlatformSpecifics {
   public static final String NEW_LINE = System.getProperty("line.separator");
   public static final Pattern CPP_RE = Pattern.compile("(.+(?:\\.(?:cpp|c|cc|C|cxx|h|hxx|hpp|ipp))):[(]?([\\d]+)[)]?");
+  public static final Pattern FORT_RE = Pattern.compile("(?i)(.+(?:\\.(?:f90|f|f77|for))):([\\d]+).([\\d]+):");
   private static final Pattern OBJ_FILE_RE = Pattern.compile("([^\\s]+)(\\.(o|os|obj))$");
   private static final String SCONS_EXECUTABLE_NAME = isWindows() ? "scons.bat" : "scons";
 

--- a/ch.hsr.ifs.sconsolidator.core/src/ch/hsr/ifs/sconsolidator/core/console/BuildConsole.java
+++ b/ch.hsr.ifs.sconsolidator.core/src/ch/hsr/ifs/sconsolidator/core/console/BuildConsole.java
@@ -44,6 +44,7 @@ public class BuildConsole implements SConsConsole {
 
   private void addCompileErrorListener(IProject project) {
     console.addPatternMatchListener(new CompileErrorPatternMatcher(project));
+    console.addPatternMatchListener(new FortranErrorPatternMatcher(project));
   }
 
   private static String getConsoleName(IProject project) {

--- a/ch.hsr.ifs.sconsolidator.core/src/ch/hsr/ifs/sconsolidator/core/console/CompileErrorPatternMatcher.java
+++ b/ch.hsr.ifs.sconsolidator.core/src/ch/hsr/ifs/sconsolidator/core/console/CompileErrorPatternMatcher.java
@@ -4,52 +4,24 @@ import java.util.regex.Matcher;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.IWorkspaceRoot;
-import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.debug.ui.console.FileLink;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.ui.console.IOConsole;
-import org.eclipse.ui.console.IPatternMatchListener;
 import org.eclipse.ui.console.PatternMatchEvent;
-import org.eclipse.ui.console.TextConsole;
-
 import ch.hsr.ifs.sconsolidator.core.PlatformSpecifics;
-import ch.hsr.ifs.sconsolidator.core.SConsHelper;
+
 import ch.hsr.ifs.sconsolidator.core.SConsPlugin;
 
-public class CompileErrorPatternMatcher implements IPatternMatchListener {
-  private final IProject project;
-  private final String startPath;
-
+public class CompileErrorPatternMatcher extends ErrorPatternMatcher {
   public CompileErrorPatternMatcher(IProject project) {
-    this.project = project;
-    startPath = SConsHelper.determineStartingDirectory(project);
-  }
-
-  @Override
-  public int getCompilerFlags() {
-    return 0;
-  }
-
-  @Override
-  public String getLineQualifier() {
-    return null;
+	  super(project);
   }
 
   @Override
   public String getPattern() {
     return PlatformSpecifics.CPP_RE.pattern();
   }
-
-  @Override
-  public void connect(TextConsole console) {}
-
-  @Override
-  public void disconnect() {}
 
   @Override
   public void matchFound(PatternMatchEvent event) {
@@ -72,32 +44,5 @@ public class CompileErrorPatternMatcher implements IPatternMatchListener {
     } catch (BadLocationException e) {
       SConsPlugin.log(e);
     }
-  }
-
-  private IFile findFile(String fileName) {
-    IResource foundMember = project.findMember(fileName);
-
-    if (foundMember == null) {
-      foundMember = findRelativeToSConsProject(fileName);
-
-      if (foundMember == null) {
-        foundMember = findInWorkspace(fileName);
-      }
-    }
-    return (IFile) foundMember;
-  }
-
-  private IResource findInWorkspace(String fileName) {
-    IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
-    return workspaceRoot.getFileForLocation(new Path(startPath).append(fileName));
-  }
-
-  private IResource findRelativeToSConsProject(String fileName) {
-    IPath projLoc = project.getLocation();
-    if (projLoc == null)
-      return null;
-    IPath path = projLoc.makeRelativeTo(new Path(startPath));
-    String newPath = new Path(fileName).makeRelativeTo(path).toOSString();
-    return project.findMember(newPath);
   }
 }

--- a/ch.hsr.ifs.sconsolidator.core/src/ch/hsr/ifs/sconsolidator/core/console/ErrorPatternMatcher.java
+++ b/ch.hsr.ifs.sconsolidator.core/src/ch/hsr/ifs/sconsolidator/core/console/ErrorPatternMatcher.java
@@ -1,0 +1,69 @@
+package ch.hsr.ifs.sconsolidator.core.console;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.ui.console.IPatternMatchListener;
+import org.eclipse.ui.console.TextConsole;
+
+import ch.hsr.ifs.sconsolidator.core.SConsHelper;
+
+public abstract class ErrorPatternMatcher implements IPatternMatchListener {
+
+	protected final IProject project;
+	protected final String startPath;
+
+	public ErrorPatternMatcher(IProject project) {
+		super();
+		this.project = project;
+		this.startPath = SConsHelper.determineStartingDirectory(project);
+	}
+
+	@Override
+	public int getCompilerFlags() {
+	    return 0;
+	  }
+
+	@Override
+	public String getLineQualifier() {
+	    return null;
+	  }
+
+	@Override
+	public void connect(TextConsole console) {}
+
+	@Override
+	public void disconnect() {}
+
+	protected IFile findFile(String fileName) {
+	    IResource foundMember = project.findMember(fileName);
+	
+	    if (foundMember == null) {
+	      foundMember = findRelativeToSConsProject(fileName);
+	
+	      if (foundMember == null) {
+	        foundMember = findInWorkspace(fileName);
+	      }
+	    }
+	    return (IFile) foundMember;
+	  }
+
+	private IResource findInWorkspace(String fileName) {
+	    IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
+	    return workspaceRoot.getFileForLocation(new Path(startPath).append(fileName));
+	  }
+
+	private IResource findRelativeToSConsProject(String fileName) {
+	    IPath projLoc = project.getLocation();
+	    if (projLoc == null)
+	      return null;
+	    IPath path = projLoc.makeRelativeTo(new Path(startPath));
+	    String newPath = new Path(fileName).makeRelativeTo(path).toOSString();
+	    return project.findMember(newPath);
+	  }
+	
+}

--- a/ch.hsr.ifs.sconsolidator.core/src/ch/hsr/ifs/sconsolidator/core/console/FortranErrorPatternMatcher.java
+++ b/ch.hsr.ifs.sconsolidator.core/src/ch/hsr/ifs/sconsolidator/core/console/FortranErrorPatternMatcher.java
@@ -1,0 +1,51 @@
+package ch.hsr.ifs.sconsolidator.core.console;
+
+import java.util.regex.Matcher;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.debug.ui.console.FileLink;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.ui.console.IOConsole;
+import org.eclipse.ui.console.IPatternMatchListener;
+import org.eclipse.ui.console.PatternMatchEvent;
+
+import ch.hsr.ifs.sconsolidator.core.PlatformSpecifics;
+import ch.hsr.ifs.sconsolidator.core.SConsPlugin;
+
+public class FortranErrorPatternMatcher extends ErrorPatternMatcher implements IPatternMatchListener {
+
+	public FortranErrorPatternMatcher(IProject project) {
+		super(project);
+	}
+
+	@Override
+	public void matchFound(PatternMatchEvent event) {
+	    try {
+	        IOConsole console = (IOConsole) event.getSource();
+	        IDocument document = console.getDocument();
+	        int offset = event.getOffset();
+	        int length = event.getLength();
+	        String message = document.get(offset, length);
+	        Matcher m = PlatformSpecifics.FORT_RE.matcher(message);
+	        if (!m.matches()) return;
+	        String fileName = m.group(1);
+	        IFile file = findFile(fileName);
+
+	        if (file != null && file.exists()) {
+	          String lineNumber = m.group(2);
+	          FileLink link = new FileLink(file, null, -1, -1, Integer.parseInt(lineNumber));
+	          console.addHyperlink(link, offset, length);
+	        }
+	      } catch (BadLocationException e) {
+	        SConsPlugin.log(e);
+	      }
+	}
+
+	@Override
+	public String getPattern() {
+		return PlatformSpecifics.FORT_RE.pattern();
+	}
+
+}

--- a/ch.hsr.ifs.sconsolidator.core/src/ch/hsr/ifs/sconsolidator/core/console/interactive/InteractiveConsole.java
+++ b/ch.hsr.ifs.sconsolidator.core/src/ch/hsr/ifs/sconsolidator/core/console/interactive/InteractiveConsole.java
@@ -45,6 +45,7 @@ import ch.hsr.ifs.sconsolidator.core.base.utils.FileUtil;
 import ch.hsr.ifs.sconsolidator.core.base.utils.StringUtil;
 import ch.hsr.ifs.sconsolidator.core.base.utils.UIUtil;
 import ch.hsr.ifs.sconsolidator.core.console.CompileErrorPatternMatcher;
+import ch.hsr.ifs.sconsolidator.core.console.FortranErrorPatternMatcher;
 import ch.hsr.ifs.sconsolidator.core.console.interactive.actions.BuildCurrentTargetAction;
 import ch.hsr.ifs.sconsolidator.core.console.interactive.actions.CleanCurrentTargetAction;
 import ch.hsr.ifs.sconsolidator.core.console.interactive.actions.RedoLastTargetAction;
@@ -90,6 +91,7 @@ public final class InteractiveConsole extends IOConsole {
 
   private void addCompileErrorListener() {
     addPatternMatchListener(new CompileErrorPatternMatcher(project));
+    addPatternMatchListener(new FortranErrorPatternMatcher(project));
   }
 
   private void initToolbarActions() {


### PR DESCRIPTION
This change adds markers to the output of GNU Fortran (ie GCC's Fortran compiler), as well as making it slightly easier to add further marker types in future.

If there are existing unit tests for the C++ markers, and someone can point me toward them, I'll add unit tests for the Fortran markers also.