### PR TITLE
Fixed #11

### DIFF
--- a/ch.hsr.ifs.sconsolidator.core/scons_files/BuildInfoCollector.py
+++ b/ch.hsr.ifs.sconsolidator.core/scons_files/BuildInfoCollector.py
@@ -147,10 +147,13 @@ def collect_macros_from_cc_flags(environ):
             if flag is not None and isinstance(flag, str) and flag.startswith('-D'))
 
 
+def get_compiler_flags(lang, environ):
+    return (environ['CXXFLAGS'] if lang == 'c++' else environ['CCFLAGS'])
+
+
 def collect_sys_macros(lang, environ):
-    process = SCons.Action._subproc(environ, 
-            [get_compiler(environ), '-E', '-dM', get_gcc_lang_param(lang), '-'],
-            stdin='devnull', stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+    command = [get_compiler(environ), '-E', '-dM', get_gcc_lang_param(lang)] + get_compiler_flags(lang, environ) + ['-']
+    process = SCons.Action._subproc(environ, command, stdin='devnull', stderr=subprocess.PIPE, stdout=subprocess.PIPE)
     (pout, _) = process.communicate()
     sysmacros = set()
 


### PR DESCRIPTION
@marcelhuberfoo This change was contributed by a user (see #11). Worked for me in a test project (`__cpluspus` was properly set to `201402L` with my compiler which was not the case without this fix [`199711`]). What do you think?