### PR TITLE
Fix for Python3 in SConstruct and Target File Update

### DIFF
--- a/ch.hsr.ifs.sconsolidator.core.tests/.classpath
+++ b/ch.hsr.ifs.sconsolidator.core.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="lib" path="lib/jdepend-2.9.1.jar"/>

--- a/ch.hsr.ifs.sconsolidator.core.tests/META-INF/MANIFEST.MF
+++ b/ch.hsr.ifs.sconsolidator.core.tests/META-INF/MANIFEST.MF
@@ -1,11 +1,11 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: SConsolidator Core Test Plugin
+Bundle-Name: SConsolidator Core Test
 Bundle-SymbolicName: ch.hsr.ifs.sconsolidator.core.tests;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Fragment-Host: ch.hsr.ifs.sconsolidator.core;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Bundle-Vendor: IFS
+Bundle-Vendor: IFS Institute for Software
 Require-Bundle: org.junit;bundle-version="4.8.1"
 Bundle-ClassPath: lib/jdepend-2.9.1.jar,
  .

--- a/ch.hsr.ifs.sconsolidator.core/.classpath
+++ b/ch.hsr.ifs.sconsolidator.core/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry exported="true" kind="lib" path="lib/commons-exec-1.1.jar"/>

--- a/ch.hsr.ifs.sconsolidator.core/META-INF/MANIFEST.MF
+++ b/ch.hsr.ifs.sconsolidator.core/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: %CoreBundleName
+Bundle-Name: SConsolidator Core
 Bundle-SymbolicName: ch.hsr.ifs.sconsolidator.core;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
@@ -30,6 +30,6 @@ Export-Package: ch.hsr.ifs.sconsolidator.core,
  ch.hsr.ifs.sconsolidator.core.depanalysis
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: ch.hsr.ifs.sconsolidator.core.SConsPlugin
-Bundle-Vendor: %CoreBundleVendor
+Bundle-Vendor: IFS Institute for Software
 Bundle-ClassPath: .,
  lib/commons-exec-1.1.jar

--- a/ch.hsr.ifs.sconsolidator.core/scons_files/SConstruct
+++ b/ch.hsr.ifs.sconsolidator.core/scons_files/SConstruct
@@ -9,11 +9,11 @@ from SConfig import *
 # Minimum SCons and Python version for plugin
 # SCons >= 2.0.0 drops Python pre-2.4 support!
 EnsureSConsVersion(2, 0)
-EnsurePythonVersion(2, 4)
+EnsurePythonVersion(2, 7)
 
 # Set SCons options
 WARN_PREFIX = "warn"
-for (k, v) in SCONS_OPTIONS.iteritems():
+for (k, v) in SCONS_OPTIONS.items():
     if k.startswith(WARN_PREFIX):
         SetOption(WARN_PREFIX, v[len(WARN_PREFIX) + 1:])
     else:
@@ -27,7 +27,7 @@ def filter_includes(flags):
 
 # Important to find compilers in system path to be in
 # line with Eclipse CDT
-env = Environment(ENV={'PATH': os.environ['PATH'], 'TEMP' : os.environ['TEMP']})
+env = Environment(ENV={'PATH': os.environ['PATH'], 'TEMP' : os.environ['TEMP']}) if 'TEMP' in os.environ else Environment(ENV={'PATH': os.environ['PATH']})
 
 if TOOLCHAIN_NAME.startswith('mingw') or TOOLCHAIN_NAME.startswith('cygwin'):
     Tool('mingw')(env) # Prefer MinGW over other compilers like cl.exe
@@ -54,7 +54,7 @@ pic = PROJECT_TYPE == 'so'
 # Setup pre- and post-build steps
 def call_command(command, msg):
     """Calls the given command and prints msg before."""
-    print msg
+    print(msg)
     try:
         p = Popen(command)
         os.waitpid(p.pid, 0)
@@ -80,7 +80,7 @@ post = Action(execute_post_build_action, POST_BUILD_DESC)
 
 # Search source directories for files
 main_source_dir = os.path.abspath('.')
-for subdir, excludes in SOURCE_PATHS.iteritems():
+for subdir, excludes in SOURCE_PATHS.items():
     if subdir == PROJECT_NAME:
         sconscript_path = 'SConscript'
         source_dir = main_source_dir
@@ -104,7 +104,7 @@ elif PROJECT_TYPE == "so": # Shared library
 elif PROJECT_TYPE == "a": # Static library
     artifact = env.StaticLibrary(**params)
 else:
-    print "Unknown project type!"
+    print("Unknown project type!")
     Exit(1)
 
 # Dependencies for pre- and post-build commands
@@ -124,7 +124,7 @@ if COMP_INCLUDES_INTO_CCFLAGS:
         # SCons 0.98
         env['CXXCOM'] = "$CXX -o $TARGET -c $_CCCOMCOM $CXXFLAGS $CCFLAGS $SOURCES"
     else:
-        print "Unexpected default CXXCOM"
+        print("Unexpected default CXXCOM")
         Exit(1)
 
     if env['SHCXXCOM'] == "$SHCXX -o $TARGET -c $SHCXXFLAGS $_CCCOMCOM $SOURCES":
@@ -134,5 +134,5 @@ if COMP_INCLUDES_INTO_CCFLAGS:
         # SCons 0.98
         env['SHCXXCOM'] = "$SHCXX -o $TARGET -c $_CCCOMCOM $SHCXXFLAGS $SHCCFLAGS $SOURCES"
     else:
-        print "Unexpected default SHCXXCOM"
+        print("Unexpected default SHCXXCOM")
         Exit(1)

--- a/ch.hsr.ifs.sconsolidator.depviz.feature/feature.xml
+++ b/ch.hsr.ifs.sconsolidator.depviz.feature/feature.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
       id="ch.hsr.ifs.sconsolidator.depviz.feature"
-      label="%featureName"
+      label="SConsolidator Depviz"
       version="1.0.0.qualifier"
-      provider-name="%providerName"
+      provider-name="IFS Institute for Software"
       plugin="ch.hsr.ifs.sconsolidator.depviz">
 
    <description url="http://sconsolidator.com">

--- a/ch.hsr.ifs.sconsolidator.depviz/.classpath
+++ b/ch.hsr.ifs.sconsolidator.depviz/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/ch.hsr.ifs.sconsolidator.depviz/META-INF/MANIFEST.MF
+++ b/ch.hsr.ifs.sconsolidator.depviz/META-INF/MANIFEST.MF
@@ -1,12 +1,12 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: %DepVizBundleName
+Bundle-Name: SConsolidator Depviz Plug-in
 Bundle-SymbolicName: ch.hsr.ifs.sconsolidator.depviz;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: ch.hsr.ifs.sconsolidator.depviz.DependencyVisualizationPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Bundle-Vendor: %DepVizBundleVendor
+Bundle-Vendor: IFS Institute for Software
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.5.0",
  org.eclipse.core.resources;bundle-version="3.5.0",
  org.eclipse.ui;bundle-version="3.5.0",

--- a/ch.hsr.ifs.sconsolidator.feature/feature.xml
+++ b/ch.hsr.ifs.sconsolidator.feature/feature.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
       id="ch.hsr.ifs.sconsolidator.feature"
-      label="%featureName"
+      label="SConsolidator"
       version="1.0.0.qualifier"
-      provider-name="%providerName"
+      provider-name="IFS Institute for Software"
       plugin="ch.hsr.ifs.sconsolidator.core">
 
    <description url="http://sconsolidator.com">

--- a/ch.hsr.ifs.sconsolidator.help/META-INF/MANIFEST.MF
+++ b/ch.hsr.ifs.sconsolidator.help/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: %bundleName
+Bundle-Name: SConsolidator Help
 Bundle-SymbolicName: ch.hsr.ifs.sconsolidator.help; singleton:=true
 Bundle-Version: 1.0.0.qualifier
-Bundle-Vendor: %bundleVendor
+Bundle-Vendor: IFS Institute for Software

--- a/ch.hsr.ifs.sconsolidator.swtbottests/.classpath
+++ b/ch.hsr.ifs.sconsolidator.swtbottests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>

--- a/ch.hsr.ifs.sconsolidator.swtbottests/META-INF/MANIFEST.MF
+++ b/ch.hsr.ifs.sconsolidator.swtbottests/META-INF/MANIFEST.MF
@@ -1,10 +1,10 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: %Bundle-Name
+Bundle-Name: SConsolidator SWTBotTest
 Bundle-SymbolicName: ch.hsr.ifs.sconsolidator.swtbottests
 Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: ch.hsr.ifs.sconsolidator.swtbottests.SWTTestPlugin
-Bundle-Vendor: %Bundle-Vendor
+Bundle-Vendor: IFS Institute for Software
 Require-Bundle: org.eclipse.core.runtime,
  org.junit;bundle-version="4.8.1",
  org.eclipse.swtbot.swt.finder;bundle-version="2.0.4",

--- a/ch.hsr.ifs.sconsolidator.swtbottests/OSGI-INF/l10n/bundle.properties
+++ b/ch.hsr.ifs.sconsolidator.swtbottests/OSGI-INF/l10n/bundle.properties
@@ -1,3 +1,3 @@
 #Properties file for ch.hsr.ifs.sconsolidator.swtbottests
-Bundle-Vendor = IFS
-Bundle-Name = SConsolidator SWTBot Tests
+Bundle-Vendor = IFS Institute for Software
+Bundle-Name = SConsolidator SWTBotTest

--- a/ch.hsr.ifs.sconsolidator.target/ch.hsr.ifs.sconsolidator-oxygen.target
+++ b/ch.hsr.ifs.sconsolidator.target/ch.hsr.ifs.sconsolidator-oxygen.target
@@ -1,28 +1,24 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="Sconsolidator Oxygen Target" sequenceNumber="109">
-<locations>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.cdt.sdk.feature.group" version="9.3.0.201706122201"/>
-<unit id="org.eclipse.emf.sdk.feature.group" version="2.13.0.v20170609-0928"/>
-<unit id="org.eclipse.gef.sdk.feature.group" version="3.11.0.201606061308"/>
-<unit id="org.eclipse.zest.sdk.feature.group" version="1.7.0.201606061308"/>
-<repository location="http://download.eclipse.org/releases/oxygen"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.6.0.201706141832"/>
-<unit id="org.eclipse.swtbot.feature.group" version="2.6.0.201706141832"/>
-<unit id="org.eclipse.swtbot.forms.feature.group" version="2.6.0.201706141832"/>
-<unit id="org.eclipse.swtbot.ide.feature.group" version="2.6.0.201706141832"/>
-<repository location="http://download.eclipse.org/technology/swtbot/releases/latest/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="ch.hsr.ifs.cdttesting.feature.feature.group" version="9.3.0.201707120748"/>
-<repository location="https://cevelop.com/cdt-testing/9.3.0"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.platform.sdk" version="4.7.0.I20170612-0950"/>
-<unit id="org.eclipse.sdk.ide" version="4.7.0.I20170612-0950"/>
-<repository location="http://download.eclipse.org/eclipse/updates/4.7"/>
-</location>
-</locations>
+<?pde?>
+<!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
+<target name="SConsolidator Oxygen Target" sequenceNumber="1510046948">
+  <locations>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="ch.hsr.ifs.cdttesting.feature.feature.group" version="9.3.0.201707120748"/>
+      <repository location="https://cevelop.com/cdt-testing/9.3.0"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.cdt.sdk.feature.group" version="9.3.2.201709131603"/>
+      <unit id="org.eclipse.zest.sdk.feature.group" version="1.7.0.201606061308"/>
+      <repository location="http://download.eclipse.org/releases/oxygen"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.platform.sdk" version="4.7.1.M20171009-0410"/>
+      <repository location="http://download.eclipse.org/eclipse/updates/4.7"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.6.0.201706141832"/>
+      <repository location="http://download.eclipse.org/technology/swtbot/releases/latest/"/>
+    </location>
+  </locations>
 </target>

--- a/ch.hsr.ifs.sconsolidator.target/ch.hsr.ifs.sconsolidator-oxygen.tpd
+++ b/ch.hsr.ifs.sconsolidator.target/ch.hsr.ifs.sconsolidator-oxygen.tpd
@@ -1,0 +1,20 @@
+target "SConsolidator Oxygen Target"
+
+with source requirements
+
+location "https://cevelop.com/cdt-testing/9.3.0" {
+	ch.hsr.ifs.cdttesting.feature.feature.group [9.3.0,9.4.0)
+}
+
+location "http://download.eclipse.org/releases/oxygen" {
+	org.eclipse.cdt.sdk.feature.group [9.3.0,9.4.0)
+	org.eclipse.zest.sdk.feature.group [1.7.0,1.8.0)
+}
+
+location "http://download.eclipse.org/eclipse/updates/4.7" {
+	org.eclipse.platform.sdk [4.7.0,4.8.0)
+}
+
+location "http://download.eclipse.org/technology/swtbot/releases/latest/" {
+	org.eclipse.swtbot.eclipse.feature.group [2.6.0,2.7.0)
+}


### PR DESCRIPTION
- TEMP is not always available as an environment variable so it's now optional
- Python3 requires the use of .items() instead of .iteritems() and parentheses for printing
- Update .target and created .tpd file to easily update it
- Bumped to JRE to 1.8 since this is the default in most modern systems