### PR TITLE
Fix build info collector crash

### DIFF
--- a/ch.hsr.ifs.sconsolidator.core.tests/scons_files/test_projects/gartenbau/BuildInfoCollector.py
+++ b/ch.hsr.ifs.sconsolidator.core.tests/scons_files/test_projects/gartenbau/BuildInfoCollector.py
@@ -79,7 +79,7 @@ def collect_sys_includes(lang, environ):
                     [get_compiler(environ), '-v', get_gcc_lang_param(lang)] + get_compiler_flags(lang, environ) + [in_path, '-o', out_path],
                     stdin='devnull', stderr=subprocess.PIPE, stdout=subprocess.PIPE)
                 (_, perr) = process.communicate()
-                return perr
+                return perr.decode()
 
     def parse_includes(cc_output):
         cc_output = cc_output.replace('\r', '')
@@ -160,7 +160,7 @@ def collect_sys_macros(lang, environ):
     (pout, _) = process.communicate()
     sysmacros = set()
 
-    for it in re.finditer('^#define (.*) (.*)$', pout, re.M):
+    for it in re.finditer('^#define (.*) (.*)$', pout.decode(), re.M):
         sysmacros.add('%s=%s' % (it.groups()[0], it.groups()[1].strip()))
     return sysmacros
 

--- a/ch.hsr.ifs.sconsolidator.core/scons_files/BuildInfoCollector.py
+++ b/ch.hsr.ifs.sconsolidator.core/scons_files/BuildInfoCollector.py
@@ -79,7 +79,7 @@ def collect_sys_includes(lang, environ):
                     [get_compiler(environ), '-v', get_gcc_lang_param(lang)] + get_compiler_flags(lang, environ) + [in_path, '-o', out_path],
                     stdin='devnull', stderr=subprocess.PIPE, stdout=subprocess.PIPE)
                 (_, perr) = process.communicate()
-                return perr
+                return perr.decode()
 
     def parse_includes(cc_output):
         cc_output = cc_output.replace('\r', '')
@@ -160,7 +160,7 @@ def collect_sys_macros(lang, environ):
     (pout, _) = process.communicate()
     sysmacros = set()
 
-    for it in re.finditer('^#define (.*) (.*)$', pout, re.M):
+    for it in re.finditer('^#define (.*) (.*)$', pout.decode(), re.M):
         sysmacros.add('%s=%s' % (it.groups()[0], it.groups()[1].strip()))
     return sysmacros
 

--- a/ch.hsr.ifs.sconsolidator.core/scons_files/BuildInfoCollector.py
+++ b/ch.hsr.ifs.sconsolidator.core/scons_files/BuildInfoCollector.py
@@ -79,7 +79,10 @@ def collect_sys_includes(lang, environ):
                     [get_compiler(environ), '-v', get_gcc_lang_param(lang)] + get_compiler_flags(lang, environ) + [in_path, '-o', out_path],
                     stdin='devnull', stderr=subprocess.PIPE, stdout=subprocess.PIPE)
                 (_, perr) = process.communicate()
-                return perr.decode()
+                try:
+                    return perr.decode()
+                except AttributeError:
+                    return perr
 
     def parse_includes(cc_output):
         cc_output = cc_output.replace('\r', '')
@@ -127,8 +130,11 @@ def collect_macros_from_cpp_defines(environ):
         return '{macro}={value}'.format(**locals())
 
     def handle_dict(d):
-        return set(macro_binding(k, v) for (k, v) in d.iteritems())
-    
+        try:
+            return set(macro_binding(k, v) for (k, v) in d.iteritems())
+        except AttributeError:
+            return set(macro_binding(k, v) for (k, v) in d.items())
+
     cpp_defines = environ['CPPDEFINES']
 
     if isinstance(cpp_defines, (list, tuple)):
@@ -160,7 +166,11 @@ def collect_sys_macros(lang, environ):
     (pout, _) = process.communicate()
     sysmacros = set()
 
-    for it in re.finditer('^#define (.*) (.*)$', pout.decode(), re.M):
+    try:
+        pout = pout.decode()
+    except AttributeError:
+        pass
+    for it in re.finditer('^#define (.*) (.*)$', pout, re.M):
         sysmacros.add('%s=%s' % (it.groups()[0], it.groups()[1].strip()))
     return sysmacros
 


### PR DESCRIPTION
I found that BuildInfoCollector.py was crashing on my machine (Windows 10, Eclipse 4.7.3a/CDT 9.4.3, Python 3.7). The problem was that it was getting a byte string back from executing the compiler but then treating it like a regular string, as was possible in Python 2 IIRC.

Unfortunately I can't run the test suite - the repository at http://cevelop.com/cdt-testing/9.4.0 has gone away, and I couldn't find a new URL for it.