### PR TITLE
Made build info output deterministic

### DIFF
--- a/ch.hsr.ifs.sconsolidator.core.tests/scons_files/test_projects/gartenbau/BuildInfoCollector.py
+++ b/ch.hsr.ifs.sconsolidator.core.tests/scons_files/test_projects/gartenbau/BuildInfoCollector.py
@@ -183,6 +183,7 @@ def write_build_infos(includes, macros, environ):
                 strings.append("'%s'" % '='.join(obj))
             else:
                 strings.append("'%s'" % obj)
+        strings.sort()
         return ','.join([environ.subst(string) for string in strings])
 
     print('USER_INCLUDES = [%s]' % to_string(includes, environ))

--- a/ch.hsr.ifs.sconsolidator.core/scons_files/BuildInfoCollector.py
+++ b/ch.hsr.ifs.sconsolidator.core/scons_files/BuildInfoCollector.py
@@ -183,6 +183,7 @@ def write_build_infos(includes, macros, environ):
                 strings.append("'%s'" % '='.join(obj))
             else:
                 strings.append("'%s'" % obj)
+        strings.sort()
         return ','.join([environ.subst(string) for string in strings])
 
     print('USER_INCLUDES = [%s]' % to_string(includes, environ))


### PR DESCRIPTION
BuildInfoCollector was putting the defines it discovered into an unordered set but not sorting afterwards, so project file changes were hard to understand.

Unfortunately I can't run the test suite - the repository at http://cevelop.com/cdt-testing/9.4.0 has gone away, and I couldn't find a new URL for it.