### PR TITLE
Fixed mis-parse of #defines with spaces in value

### DIFF
--- a/ch.hsr.ifs.sconsolidator.core.tests/scons_files/test_projects/gartenbau/BuildInfoCollector.py
+++ b/ch.hsr.ifs.sconsolidator.core.tests/scons_files/test_projects/gartenbau/BuildInfoCollector.py
@@ -160,7 +160,7 @@ def collect_sys_macros(lang, environ):
     (pout, _) = process.communicate()
     sysmacros = set()
 
-    for it in re.finditer('^#define (.*) (.*)$', pout, re.M):
+    for it in re.finditer('^#define ([a-zA-Z0-9_]*(?:\(.*\))?) (.*)$', pout, re.M):
         sysmacros.add('%s=%s' % (it.groups()[0], it.groups()[1].strip()))
     return sysmacros
 

--- a/ch.hsr.ifs.sconsolidator.core/scons_files/BuildInfoCollector.py
+++ b/ch.hsr.ifs.sconsolidator.core/scons_files/BuildInfoCollector.py
@@ -160,7 +160,7 @@ def collect_sys_macros(lang, environ):
     (pout, _) = process.communicate()
     sysmacros = set()
 
-    for it in re.finditer('^#define (.*) (.*)$', pout, re.M):
+    for it in re.finditer('^#define ([a-zA-Z0-9_]*(?:\(.*\))?) (.*)$', pout, re.M):
         sysmacros.add('%s=%s' % (it.groups()[0], it.groups()[1].strip()))
     return sysmacros
 


### PR DESCRIPTION
My toolchain (GCC ARM Embedded) has some macros that look like:
`#define __INTMAX_C(c) c ## LL`
These were being mis-parsed as e.g. `__INTMAX_C(c) c ##=LL` rather than `__INTMAX_C_(c)=c ## LL`, causing some weirdness when Eclipse tried to understand uses of std::array.

Unfortunately I can't run the test suite - the repository at http://cevelop.com/cdt-testing/9.4.0 has gone away, and I couldn't find a new URL for it.